### PR TITLE
Make proper synchronization for context and script

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPlugin.groovy
@@ -150,24 +150,38 @@ class GlobalEventsPlugin extends Plugin implements Describable<GlobalEventsPlugi
                     params.put("env", envVars);
                     params.put("jenkins", jenkins)
                     params.put("log", log)
-                    // add all parameters from the in-memory context...
-                    params.put("context", context)
-                    log.finer(">>> Executing groovy script - parameters: ${params.keySet()}")
 
-                    groovyScript.setBinding(new Binding(params))
+                    def syncStart = System.currentTimeMillis()
+                    def executionStart
 
-                    def start = System.currentTimeMillis()
-                    def response = groovyScript.run()
-                    def durationMillis = System.currentTimeMillis() - start
-                    if (response instanceof Map) {
-                        // if response, add the values to the in-memory context...
-                        Map responseMap = (Map) response
-                        log.finer(">>> Adding keys to context: ${response.keySet()}")
-                        context.putAll(responseMap)
-                    } else {
-                        log.finer(">>> Ignoring response - value is null or not a Map. response=$response")
+                    synchronized (groovyScript) {
+                        // add all parameters from the in-memory context...
+                        params.put("context", context)
+                        log.finer(">>> Executing groovy script - parameters: ${params.keySet()}")
+
+                        groovyScript.setBinding(new Binding(params))
+
+                        executionStart = System.currentTimeMillis()
+                        def response = groovyScript.run()
+
+                        if (response instanceof Map) {
+                            // if response, add the values to the in-memory context...
+                            Map responseMap = (Map) response
+                            log.finer(">>> Adding keys to context: ${response.keySet()}")
+                            context.putAll(responseMap)
+                        } else {
+                            log.finer(">>> Ignoring response - value is null or not a Map. response=$response")
+                        }
                     }
-                    log.fine(""">>> Executing groovy script completed successfully. durationMillis="$durationMillis" """)
+
+                    def totalDurationMillis = System.currentTimeMillis() - syncStart
+                    def executionDurationMillis = System.currentTimeMillis() - executionStart
+                    def synchronizationMillis=totalDurationMillis-executionDurationMillis
+
+                    log.finer(">>> Executing groovy script completed successfully. "+
+                            "totalDurationMillis='$totalDurationMillis'," +
+                            "executionDurationMillis='$executionDurationMillis'," +
+                            "synchronizationMillis=`$synchronizationMillis`")
                 } else {
                     log.warning(">>> Skipping execution, Groovy code was null or blank.")
                 }

--- a/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPluginTest.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPluginTest.groovy
@@ -4,6 +4,11 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
 
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.FutureTask
+
 /**
  * Created by nickgrealy@gmail.com.
  */
@@ -73,6 +78,56 @@ class GlobalEventsPluginTest {
             [ccc:333]
             """), [:])
         assert plugin.context == [aaa:111,bbb:222,ccc:333]
+    }
+
+    @Test
+    void testCounter(){
+        int expectedValue = 1000
+        plugin.context = [total:0]
+        plugin.setOnEventGroovyCode("context.total += 1")
+        for(int i=0; i<expectedValue; i++) {
+            plugin.safeExecOnEventGroovyCode(logger, [:])
+            assert plugin.context == [total: i+1]
+        }
+        assert plugin.context == [total:expectedValue]
+    }
+
+    @Test
+    void testConcurrentCounter(){
+        int expectedValue = 1000
+        plugin.context = [total:0]
+        plugin.setOnEventGroovyCode("context.total += 1")
+        Callable<Integer> callable = new Callable() {
+            @Override
+            Integer call() throws Exception {
+                for(int i=0; i<expectedValue/5; i++) {
+                    plugin.safeExecOnEventGroovyCode(logger, [:])
+                }
+                return 0;
+            };
+        };
+
+        ExecutorService executors = Executors.newFixedThreadPool(5);
+        FutureTask task1 = new FutureTask(callable);
+        FutureTask task2 = new FutureTask(callable);
+        FutureTask task3 = new FutureTask(callable);
+        FutureTask task4 = new FutureTask(callable);
+        FutureTask task5 = new FutureTask(callable);
+        executors.execute(task1);
+        executors.execute(task2);
+        executors.execute(task3);
+        executors.execute(task4);
+        executors.execute(task5);
+
+        while (true) {
+            if (task1.isDone() && task2.isDone() && task3.isDone() && task4.isDone() && task5.isDone() ) {
+                break;
+            }
+
+            Thread.sleep(1000);
+        }
+
+        assert plugin.context == [total:expectedValue]
     }
 
     @Test


### PR DESCRIPTION
@nickgrealy Hi! I saw that you had removed `synchronized` from method, it's ok in my case, but I saw that in `README` you recommend people to use this plugin as counter. In this case everything will be broken. I add a little bit cheaper synchronization and (the most important part) test for it. So, if you are interesting in it, you can play with `synchronized` keyword and compare test results. 
Second problem, why it's better to keep some synchronization - we have only one instance of Script right now, so, when you are setting Binding without synchronization, you can set it for different thread/run.

As I said earlier, in my case it's ok to use plugin without synchronization, because we are not using anything from context. But somebody can find this behavior unexpected.