### PR TITLE
Only execute script for registered events (to mitigate performance impacts)

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/globalEventsPlugin/GlobalRunListener.java
+++ b/src/main/groovy/org/jenkinsci/plugins/globalEventsPlugin/GlobalRunListener.java
@@ -37,36 +37,44 @@ public class GlobalRunListener extends RunListener<Run> {
 
     @Override
     public void onDeleted(final Run run) {
-        this.getParentPluginDescriptor().safeExecOnEventGroovyCode(log, new HashMap<Object, Object>() {{
-            put("run", run);
-            put("event", Event.JOB_DELETED);
-        }});
+        if (getParentPluginDescriptor().getOnJobDeleted()) {
+            this.getParentPluginDescriptor().safeExecOnEventGroovyCode(log, new HashMap<Object, Object>() {{
+                put("run", run);
+                put("event", Event.JOB_DELETED);
+            }});
+        }
     }
 
     @Override
     public void onStarted(final Run run, final TaskListener listener) {
-        this.getParentPluginDescriptor().safeExecOnEventGroovyCode(log, new HashMap<Object, Object>() {{
-            put("run", run);
-            put("listener", listener);
-            put("event", Event.JOB_STARTED);
-        }});
+        if (getParentPluginDescriptor().getOnJobStarted()) {
+            this.getParentPluginDescriptor().safeExecOnEventGroovyCode(log, new HashMap<Object, Object>() {{
+                put("run", run);
+                put("listener", listener);
+                put("event", Event.JOB_STARTED);
+            }});
+        }
     }
 
     @Override
     public void onFinalized(final Run run) {
-        this.getParentPluginDescriptor().safeExecOnEventGroovyCode(log, new HashMap<Object, Object>() {{
-            put("run", run);
-            put("event", Event.JOB_FINALIZED);
-        }});
+        if (getParentPluginDescriptor().getOnJobFinalized()) {
+            this.getParentPluginDescriptor().safeExecOnEventGroovyCode(log, new HashMap<Object, Object>() {{
+                put("run", run);
+                put("event", Event.JOB_FINALIZED);
+            }});
+        }
     }
 
     @Override
     public void onCompleted(final Run run, final @Nonnull TaskListener listener) {
-        this.getParentPluginDescriptor().safeExecOnEventGroovyCode(log, new HashMap<Object, Object>() {{
-            put("run", run);
-            put("listener", listener);
-            put("event", Event.JOB_COMPLETED);
-        }});
+        if (getParentPluginDescriptor().getOnJobCompleted()) {
+            this.getParentPluginDescriptor().safeExecOnEventGroovyCode(log, new HashMap<Object, Object>() {{
+                put("run", run);
+                put("listener", listener);
+                put("event", Event.JOB_COMPLETED);
+            }});
+        }
     }
 
 }

--- a/src/main/resources/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPlugin/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPlugin/global.jelly
@@ -20,14 +20,41 @@
                     default="${descriptor.getDefaultOnEventGroovyCode()}"
                     codemirror-mode="groovy"
                     codemirror-config="mode: 'text/x-groovy',
-        lineNumbers: true,
-        matchBrackets: true,
-        onBlur: function(editor){editor.save()}"/>
+                    lineNumbers: true,
+                    matchBrackets: true,
+                    onBlur: function(editor){editor.save()}"/>
         </f:entry>
 
         <f:validateButton
                 title="${%Test Groovy Code}" progress="${%Executing...}"
                 method="testGroovyCode" with="onEventGroovyCode"/>
 
+        <f:advanced>
+            <f:entry title="Disable Synchronization">
+                <f:checkbox field="disableSynchronization"/>
+            </f:entry>
+            <f:section title="Plugin">
+                <f:entry title="Started">
+                    <f:checkbox field="onPluginStarted" checked="${onPluginStarted}"/>
+                </f:entry>
+                <f:entry title="Stopped">
+                    <f:checkbox field="onPluginStopped" checked="${onPluginStopped}"/>
+                </f:entry>
+            </f:section>
+            <f:section title="Job run">
+                <f:entry title="Started">
+                    <f:checkbox field="onJobStarted" checked="${onJobStarted}"/>
+                </f:entry>
+                <f:entry title="Completed">
+                    <f:checkbox field="onJobCompleted" checked="${onJobCompleted}"/>
+                </f:entry>
+                <f:entry title="Finalized">
+                    <f:checkbox field="onJobFinalized" checked="${onJobFinalized}"/>
+                </f:entry>
+                <f:entry title="Deleted">
+                    <f:checkbox field="onJobDeleted" checked="${onJobDeleted}"/>
+                </f:entry>
+            </f:section>
+        </f:advanced>
     </f:section>
 </j:jelly>

--- a/src/main/site/examples/3_UseJenkinsAPI.groovy
+++ b/src/main/site/examples/3_UseJenkinsAPI.groovy
@@ -1,0 +1,12 @@
+import hudson.model.*;
+import jenkins.metrics.impl.TimeInQueueAction;
+
+if (event == 'RunListener.onFinalized') {
+    // Current run/build
+    def build = Thread.currentThread().executable
+    // Action from Metrics-plugin
+    def queueAction = build.getAction(TimeInQueueAction.class)
+    def queuing = queueAction.getQueuingDurationMillis()
+
+    log.info "run_number=$build.number, run_timestamp=$build.timestamp.timeInMillis, queue_duration=$queuing"
+}

--- a/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/JenkinsTest.java
+++ b/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/JenkinsTest.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.globalEventsPlugin;
+
+import com.gargoylesoftware.htmlunit.WebAssert;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class JenkinsTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testConfig() throws Exception {
+        HtmlPage page = j.createWebClient().goTo("configure");
+        WebAssert.assertTextPresent(page, "Groovy Code");
+    }
+}


### PR DESCRIPTION
New improvements:
*	Now it’s possible to subscribe only on desired events
*	Now it’s possible to disable synchronization at all
*       Added example how to use Jenkins api instead of `run` from context.
*       End-to-End test for configuration page (extremely useful when you are changing something in .jelly).