### PR TITLE
Use Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
 language: java
 sudo: required
 jdk:
-  - oraclejdk7
+  - openjdk8
 
 # enable codecov reporting...
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-
 # disable email notifications...
 notifications:
   email: false
-
 
 # enable gradle dependency caching...
 before_cache:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Building
 
 Prerequisites:
 
-- JDK 6 (or above)
+- JDK 8 (or above)
 
 To setup for use with Intellij IDEA
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ gradlew publish - Deploy your plugin to the Jenkins Maven repository to be inclu
 gradlew server - Start a local instance of Jenkins (http://localhost:8080) with the plugin pre-installed for testing and debugging.
  */
 
-ext.enforceJavaVersion = JavaVersion.VERSION_1_7
+ext.enforceJavaVersion = JavaVersion.VERSION_1_8
 
 apply plugin: 'org.jenkins-ci.jpi'
 apply from: "$rootDir/gradle/common.gradle"
@@ -71,8 +71,7 @@ task integTest(type: Test, dependsOn: startJenkins) {
 check.dependsOn integTest
 
 jenkinsPlugin {
-    // always use latest LTS!
-    coreVersion = '2.7.1'
+    coreVersion = '2.60.3'
     shortName = project.name
     displayName = jenkinsDisplayName
     url = "https://wiki.jenkins-ci.org/display/JENKINS/$jenkinsDisplayName"
@@ -92,7 +91,7 @@ jenkinsPlugin {
 configurations { forceGroovy }
 
 dependencies {
-    forceGroovy "org.codehaus.groovy:groovy-all:2.4.7"
+    forceGroovy "org.codehaus.groovy:groovy-all:2.4.8"
     compile 'org.apache.ivy:ivy:2.4.0' // For @Grab
 
     testCompile('org.hamcrest:hamcrest-core:1.3') { force = true }

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -20,8 +20,8 @@ repositories {
 }
 
 ext {
-    groovyVersion = '2.4.7'
-    customJvmArgs = ['-XX:MaxPermSize=128m', '-Xmx128m']
+    groovyVersion = '2.4.8'
+    customJvmArgs = ['-Xmx128m']
 }
 
 configurations {

--- a/src/main/groovy/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPlugin.groovy
@@ -278,8 +278,9 @@ class GlobalEventsPlugin extends Plugin implements Describable<GlobalEventsPlugi
                         }
                     }
 
-                    def totalDurationMillis = System.currentTimeMillis() - syncStart
-                    def executionDurationMillis = System.currentTimeMillis() - executionStart
+                    def totalEnd = System.currentTimeMillis()
+                    def totalDurationMillis = totalEnd - syncStart
+                    def executionDurationMillis = totalEnd - executionStart
                     def synchronizationMillis = totalDurationMillis - executionDurationMillis
 
                     log.finer(">>> Executing groovy script completed successfully. " +

--- a/src/main/resources/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPlugin/help-onEventGroovyCode.html
+++ b/src/main/resources/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPlugin/help-onEventGroovyCode.html
@@ -22,18 +22,18 @@
         <tr>
             <td><code>log</code></td>
             <td>The plugin's logger instance.</td>
-            <td><a href="http://docs.oracle.com/javase/7/docs/api/java/util/logging/Logger.html">java.util.Logger</a>
+            <td><a href="http://docs.oracle.com/javase/8/docs/api/java/util/logging/Logger.html">java.util.Logger</a>
             </td>
         </tr>
         <tr>
             <td><code>context</code></td>
             <td>A Map containing variables, which are persisted between code executions.</td>
-            <td><a href="http://docs.oracle.com/javase/7/docs/api/java/util/Map.html">java.util.Map</a></td>
+            <td><a href="http://docs.oracle.com/javase/8/docs/api/java/util/Map.html">java.util.Map</a></td>
         </tr>
         <tr>
             <td><code>event</code></td>
             <td>The name of the event that triggered the code (see Events below).</td>
-            <td><a href="http://docs.oracle.com/javase/7/docs/api/java/lang/String.html">java.lang.String</a></td>
+            <td><a href="http://docs.oracle.com/javase/8/docs/api/java/lang/String.html">java.lang.String</a></td>
         </tr>
         <tr>
             <td><code>jenkins</code></td>

--- a/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/integration/IntegrationTest.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/integration/IntegrationTest.groovy
@@ -20,7 +20,7 @@ class IntegrationTest {
                 'log.info GroovySystem.version',
                 '''Execution completed successfully!
 >>> Executing groovy script - parameters: [env, run, jenkins, log, event, context]
-2.4.7
+2.4.8
 >>> Ignoring response - value is null or not a Map. response=null
 >>> Executing groovy script completed successfully. totalDurationMillis='X',executionDurationMillis='X',synchronizationMillis='X\''''
         )


### PR DESCRIPTION
Java 7 is end of life since many years.
Jenkins 2.60.1 is the first Jenkins version requring Java 8.
For more details see https://jenkins.io/changelog-stable/#v2.60.1
Use 2.60.3 to get at least some more bug fixes.

@nickgrealy @markyjackson-taulia