### PR TITLE
Upgrade groovy to 2.4.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,2 @@
-buildPlugin()
+
+buildPluginWithGradle()

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ description = A Jenkins plugin, which executes groovy code when an event occurs.
 version = 1.015-SNAPSHOT
 
 jenkinsDisplayName = Groovy Events Listener Plugin
-groovyVersion = 2.4.4
+groovyVersion = 2.4.11
 
 org.gradle.daemon=false
 


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/groovy-events-listener-plugin/issues/49

Event groovy listener is not working with current jenkins version

See https://jenkins.io/changelog-stable/
Notable changes since 2.60.3:
Upgrade Groovy from 2.4.8 to 2.4.11. (Groovy 2.4.9 changelog, Groovy 2.4.10 changelog, Groovy 2.4.11 changelog)

### Changes proposed

- Upgrade Groovy from 2.4.8 to 2.4.11

### Checklist

- [ ] Includes tests covering the new functionality?
- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/groovy-events-listener-plugin/50)
<!-- Reviewable:end -->
