### PR TITLE
Update Groovy to 2.4.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ task integTest(type: Test, dependsOn: [jpi, test]) {
 check.dependsOn integTest
 
 jenkinsPlugin {
-    coreVersion = '2.60.3'
+    coreVersion = '2.143'
     shortName = project.name
     displayName = jenkinsDisplayName
     url = "https://wiki.jenkins-ci.org/display/JENKINS/$jenkinsDisplayName"
@@ -89,7 +89,7 @@ jenkinsPlugin {
 configurations { forceGroovy }
 
 dependencies {
-    forceGroovy 'org.codehaus.groovy:groovy-all:2.4.8'
+    forceGroovy "org.codehaus.groovy:groovy-all:${groovyVersion}"
     compile 'org.apache.ivy:ivy:2.4.0' // For @Grab
 
     testCompile('org.hamcrest:hamcrest-core:1.3') { force = true }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,6 @@ description = A Jenkins plugin, which executes groovy code when an event occurs.
 version = 1.015-SNAPSHOT
 
 jenkinsDisplayName = Groovy Events Listener Plugin
-groovyVersion = 2.4.11
 
 org.gradle.daemon=false
 

--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -19,7 +19,7 @@ repositories {
 }
 
 ext {
-    groovyVersion = '2.4.8'
+    groovyVersion = '2.4.12'
     customJvmArgs = ['-Xmx128m']
 }
 


### PR DESCRIPTION
Fixes #49

### Changes proposed
- Update groovy version to 2.4.12, which is used in Jenkins 2.143+

### Checklist

- [] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
