### PR TITLE
Remove unused "providedCompile" Gradle configuration

### DIFF
--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -23,14 +23,6 @@ ext {
     customJvmArgs = ['-Xmx128m']
 }
 
-configurations {
-    providedCompile
-}
-
-sourceSets.main.compileClasspath += configurations.providedCompile
-sourceSets.test.compileClasspath += configurations.providedCompile
-sourceSets.test.runtimeClasspath += configurations.providedCompile
-
 task wrapper(type: Wrapper) {
     gradleVersion = '2.14'
 


### PR DESCRIPTION
This configuration was added in the 2nd commit (3a973d5) but never used.