### PR TITLE
Use GitHub as the source of documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ jenkinsPlugin {
     coreVersion = '2.60.3'
     shortName = project.name
     displayName = jenkinsDisplayName
-    url = "https://wiki.jenkins-ci.org/display/JENKINS/$jenkinsDisplayName"
+    url = "https://github.com/jenkinsci/$project.name"
     gitHubUrl = "https://github.com/jenkinsci/$project.name"
     compatibleSinceVersion = '1.20'
     fileExtension = 'hpi'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'groovy-events-listener-plugin'


### PR DESCRIPTION
Load documentation from GitHub instead of Wiki, see https://issues.jenkins-ci.org/browse/WEBSITE-637