### PR TITLE
Fix Groovy version incompatibility in newer Jenkins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
 }
 
 jenkinsPlugin {
-    coreVersion = '2.60.3'
+    coreVersion = '2.143'
     shortName = project.name
     displayName = jenkinsDisplayName
     url = "https://github.com/jenkinsci/$project.name"
@@ -31,7 +31,7 @@ jenkinsPlugin {
 configurations { forceGroovy }
 
 dependencies {
-    forceGroovy 'org.codehaus.groovy:groovy-all:2.4.8'
+    forceGroovy 'org.codehaus.groovy:groovy-all:2.4.12'
     compile 'org.apache.ivy:ivy:2.4.0' // For @Grab
 
     testCompile 'io.cucumber:cucumber-junit:4.8.1'

--- a/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/integration/IntegrationTest.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/integration/IntegrationTest.groovy
@@ -26,7 +26,7 @@ class IntegrationTest {
         def expectedOutput = '''
             Execution completed successfully!
             >>> Executing groovy script - parameters: [env, run, jenkins, log, event, context]
-            2.4.8
+            2.4.12
             >>> Ignoring response - value is null or not a Map. response=null
             >>> Executing groovy script completed successfully. totalDurationMillis='X',executionDurationMillis='X',synchronizationMillis='X'
         '''.stripIndent()


### PR DESCRIPTION
This fixes issue #49.

In Jenkins 2.143 Groovy 2.4.11 was replaced with Groovy 2.4.12.

The Groovy packaged with the plugin and the one packaged with Jenkins should have the same version. Otherwise conflicts may occur.

I also tested it manually with Jenkins 2.204.1 by uploading the built HPI file manually and running the "Test Groovy Code" in the global configuration.