### PR TITLE
Upgrade groovy to current version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ jenkinsPlugin {
 }
 
 dependencies {
-    implementation 'org.codehaus.groovy:groovy-all:2.4.12' // add the Groovy lib to the plugin to make @Grab work
+    implementation 'org.codehaus.groovy:groovy-all:2.4.21' // add the Groovy lib to the plugin to make @Grab work
     implementation 'org.apache.ivy:ivy:2.4.0'              // required for @Grab
 
     testImplementation 'io.cucumber:cucumber-junit:4.8.1'

--- a/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/integration/IntegrationTest.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/integration/IntegrationTest.groovy
@@ -26,7 +26,7 @@ class IntegrationTest {
         def expectedOutput = '''
             Execution completed successfully!
             >>> Executing groovy script - parameters: [env, run, jenkins, log, event, context]
-            2.4.12
+            2.4.21
             >>> Ignoring response - value is null or not a Map. response=null
             >>> Executing groovy script completed successfully. totalDurationMillis='X',executionDurationMillis='X',synchronizationMillis='X'
         '''.stripIndent()


### PR DESCRIPTION
We've been investigating using the `groovy-events-listener-plugin` to help us with notifications for build events, but cannot load the plugin in current LTS releases of Jenkins as the version of Groovy is not compatible.

### Changes proposed

- Bump the Groovy version to match current Jenkins LTS releases

### Checklist

- [x] Includes tests covering the new functionality?
- [x] Ready for review
- [x] Follows CONTRIBUTING rules

### Notify

@markyjackson-taulia
