### PR TITLE
Remove usages of Commons Lang 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ You can also use `@Grab` annotations if you'd like to import external dependenci
 (thanks [Daniel](https://github.com/CoreMedia/job-dsl-plugin/commit/830fae7a0fd8a046c620600e46633166804190e3) for your solution!).
 
 ```Groovy
-@Grab('commons-lang:commons-lang:2.4')
-import org.apache.commons.lang.WordUtils
+@Grab('org.apache.commons:commons-text:1.15.0')
+import org.apache.commons.text.WordUtils
 log.info "Hello ${WordUtils.capitalize('world')}!"
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <!-- TODO fix existing violations -->
     <spotbugs.threshold>High</spotbugs.threshold>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 
   <dependencyManagement>

--- a/src/main/groovy/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/globalEventsPlugin/GlobalEventsPlugin.groovy
@@ -8,7 +8,6 @@ import hudson.util.FormValidation
 import hudson.util.LogTaskListener
 import jenkins.model.Jenkins
 import net.sf.json.JSONObject
-import org.apache.commons.lang.StringUtils
 import org.kohsuke.stapler.QueryParameter
 import org.kohsuke.stapler.StaplerRequest
 import org.kohsuke.stapler.export.ExportedBean
@@ -136,7 +135,7 @@ class GlobalEventsPlugin extends Plugin implements Describable<GlobalEventsPlugi
         private updateClasspath() {
             groovyClassLoader = new GroovyClassLoader(parentClassLoader)
 
-            if (StringUtils.isNotEmpty(classPath)) {
+            if (classPath) {
                 for (String path : classPath.split(",")) {
                     groovyClassLoader.addClasspath(path.trim())
                 }

--- a/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/integration/IntegrationTest.groovy
+++ b/src/test/groovy/org/jenkinsci/plugins/globalEventsPlugin/integration/IntegrationTest.groovy
@@ -41,8 +41,8 @@ class IntegrationTest {
     @Test
     void importDependenciesWithGrabAnnotation() {
         def groovyCode = '''
-            @Grab('commons-lang:commons-lang:2.4')
-            import org.apache.commons.lang.WordUtils
+            @Grab('org.apache.commons:commons-text:1.15.0')
+            import org.apache.commons.text.WordUtils
             log.info "Hello ${WordUtils.capitalize('world')}!"
         '''.stripIndent()
 


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this
functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- `GlobalEventsPlugin`: `StringUtils.isNotEmpty(classPath)` becomes Groovy truthiness (`if (classPath)`),
  which is the same test for a String.
- The `@Grab` example in `IntegrationTest` and the README used
  `@Grab('commons-lang:commons-lang:2.4')` with `WordUtils`; both now grab
  `org.apache.commons:commons-text` and import `org.apache.commons.text.WordUtils`, since
  `WordUtils` moved to Commons Text.
- Enabled the `ban-commons-lang-2` enforcer rule to prevent regressions.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
