### PR TITLE
Fix Groovy bytecode target for Java 21 builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,10 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
+        <configuration>
+          <!-- Groovy 2.4 supports bytecode up to Java 8. Java sources still target Java 21. -->
+          <targetBytecode>8</targetBytecode>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
## Summary

- configure GMavenPlus to emit Java 8 bytecode, the highest level supported by the plugin's Groovy 2.4 runtime
- keep Java sources on the Java 21 target selected by the updated Jenkins plugin parent
- allow the parent upgrade in #238 to build without replacing the runtime Groovy dependency

## Verification

- `mvn -B clean verify` on JDK 21: 59 tests, 0 failures, 0 errors, 1 skipped; SpotBugs reports 0 findings
- the CodeQL autobuild-equivalent `mvn -B clean package` command completes successfully
- `javap -verbose` confirms generated Groovy production and test classes use class-file version 52 (Java 8)